### PR TITLE
Update licensing to be The maxGif Contributors

### DIFF
--- a/Code/AutomatedTests/HeaderBlockTokenTest.cpp
+++ b/Code/AutomatedTests/HeaderBlockTokenTest.cpp
@@ -1,4 +1,6 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #include <max/Testing/TestSuite.hpp>
 #include <maxGif/Parsing/Tokens.hpp>

--- a/Code/Include/maxGif/Parse.hpp
+++ b/Code/Include/maxGif/Parse.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parse.inl
+++ b/Code/Include/maxGif/Parse.inl
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/ApplicationExtensionBlockToken.hpp
+++ b/Code/Include/maxGif/Parsing/ApplicationExtensionBlockToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/CommentExtensionBlockToken.hpp
+++ b/Code/Include/maxGif/Parsing/CommentExtensionBlockToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/ErrorToken.hpp
+++ b/Code/Include/maxGif/Parsing/ErrorToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/GlobalColorTableBlockToken.hpp
+++ b/Code/Include/maxGif/Parsing/GlobalColorTableBlockToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/GraphicControlExtensionBlockToken.hpp
+++ b/Code/Include/maxGif/Parsing/GraphicControlExtensionBlockToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/HeaderBlockToken.hpp
+++ b/Code/Include/maxGif/Parsing/HeaderBlockToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/ImageDataBlockToken.hpp
+++ b/Code/Include/maxGif/Parsing/ImageDataBlockToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // foudn in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/ImageDescriptorBlockToken.hpp
+++ b/Code/Include/maxGif/Parsing/ImageDescriptorBlockToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/LocalColorTableBlockToken.hpp
+++ b/Code/Include/maxGif/Parsing/LocalColorTableBlockToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/LogicalScreenDescriptorBlockToken.hpp
+++ b/Code/Include/maxGif/Parsing/LogicalScreenDescriptorBlockToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/PlainTextExtensionBlockToken.hpp
+++ b/Code/Include/maxGif/Parsing/PlainTextExtensionBlockToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/Token.hpp
+++ b/Code/Include/maxGif/Parsing/Token.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/Tokens.hpp
+++ b/Code/Include/maxGif/Parsing/Tokens.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/Include/maxGif/Parsing/TrailerBlockToken.hpp
+++ b/Code/Include/maxGif/Parsing/TrailerBlockToken.hpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/Code/TranslationUnits/EntryPoint.cpp
+++ b/Code/TranslationUnits/EntryPoint.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016, Chris Blume. All rights reserved.
+// Copyright 2016, The maxGif Contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016, Chris Blume
+Copyright 2016, The maxGif Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,9 +11,9 @@ notice, this list of conditions and the following disclaimer.
 copyright notice, this list of conditions and the following disclaimer
 in the documentation and/or other materials provided with the
 distribution.
-    * Neither the name of Chris Blume nor the
-names of its contributors may be used to endorse or promote products
-derived from this software without specific prior written permission.
+    * Neither the name of maxGif nor the names of its contributors may
+be used to endorse or promote products derived from this software
+without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT


### PR DESCRIPTION
Currently, the copyright is held by Chris Blume.
This is correct for the time being. But it is not inviting
to others who may want to contribute to the project.

Instead, create an AUTHORS file where contributors can
add themselves and change the copyright ownership to
The maxGif Contributors.

Issue #21 